### PR TITLE
wired StoreKit Plus payments

### DIFF
--- a/HeyFriend.xcodeproj/project.pbxproj
+++ b/HeyFriend.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7E01B66A2E707ED0003FFC6C /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E01B6692E707ED0003FFC6C /* StoreKit.framework */; };
+		7E01B66C2E708165003FFC6C /* StoreKit.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 7E01B66B2E708165003FFC6C /* StoreKit.storekit */; };
+		7E01B66E2E708C31003FFC6C /* EntitlementSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E01B66D2E708C31003FFC6C /* EntitlementSync.swift */; };
 		7E085C7E2E60A86E00558D8C /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 7E085C7D2E60A86E00558D8C /* FirebaseAuth */; };
 		7E085C802E60A86E00558D8C /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7E085C7F2E60A86E00558D8C /* FirebaseCore */; };
 		7E085C822E60A86E00558D8C /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 7E085C812E60A86E00558D8C /* FirebaseFirestore */; };
@@ -71,6 +74,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		7E01B6692E707ED0003FFC6C /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		7E01B66B2E708165003FFC6C /* StoreKit.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = StoreKit.storekit; sourceTree = "<group>"; };
+		7E01B66D2E708C31003FFC6C /* EntitlementSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementSync.swift; sourceTree = "<group>"; };
 		7E085C842E60A96700558D8C /* FirebaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseTest.swift; sourceTree = "<group>"; };
 		7E085C862E60AAB800558D8C /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		7E085C882E60AACF00558D8C /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
@@ -125,6 +131,7 @@
 				7E7098752E67B28F000A877D /* GoogleSignInSwift in Frameworks */,
 				7E085C802E60A86E00558D8C /* FirebaseCore in Frameworks */,
 				7E7098732E67B28F000A877D /* GoogleSignIn in Frameworks */,
+				7E01B66A2E707ED0003FFC6C /* StoreKit.framework in Frameworks */,
 				7E085C7E2E60A86E00558D8C /* FirebaseAuth in Frameworks */,
 				7E085C822E60A86E00558D8C /* FirebaseFirestore in Frameworks */,
 			);
@@ -147,6 +154,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7E01B6682E707ED0003FFC6C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7E01B6692E707ED0003FFC6C /* StoreKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		7E085C832E60A94D00558D8C /* Database */ = {
 			isa = PBXGroup;
 			children = (
@@ -317,6 +332,7 @@
 				7E4617692E46925F00EFAA01 /* HeyFriend */,
 				7E46177A2E46926100EFAA01 /* HeyFriendTests */,
 				7E4617842E46926200EFAA01 /* HeyFriendUITests */,
+				7E01B6682E707ED0003FFC6C /* Frameworks */,
 				7E4617682E46925F00EFAA01 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -334,6 +350,7 @@
 		7E4617692E46925F00EFAA01 /* HeyFriend */ = {
 			isa = PBXGroup;
 			children = (
+				7E01B66B2E708165003FFC6C /* StoreKit.storekit */,
 				7E7098782E67C022000A877D /* HeyFriend.entitlements */,
 				7E4617702E46926100EFAA01 /* Preview Content */,
 				7E46179D2E4698C000EFAA01 /* Info.plist */,
@@ -417,6 +434,7 @@
 			isa = PBXGroup;
 			children = (
 				7E4AA3BC2E6B74580011802C /* PurchaseService.swift */,
+				7E01B66D2E708C31003FFC6C /* EntitlementSync.swift */,
 			);
 			path = Billing;
 			sourceTree = "<group>";
@@ -560,6 +578,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7E01B66C2E708165003FFC6C /* StoreKit.storekit in Resources */,
 				7E4617722E46926100EFAA01 /* Preview Assets.xcassets in Resources */,
 				7E46176F2E46926100EFAA01 /* Assets.xcassets in Resources */,
 				7E7098772E67B5BE000A877D /* Assets.xcassets in Resources */,
@@ -616,6 +635,7 @@
 				7E4AA3BA2E6B73B20011802C /* PaywallView.swift in Sources */,
 				7E70986E2E67AE55000A877D /* WelcomeView.swift in Sources */,
 				7EB0A7B12E6F69830090AD40 /* FreeSessionsPill.swift in Sources */,
+				7E01B66E2E708C31003FFC6C /* EntitlementSync.swift in Sources */,
 				7E46176B2E46925F00EFAA01 /* HeyFriendApp.swift in Sources */,
 				7E2E491A2E4E4C2D0021AA2C /* RotatingGlowView.swift in Sources */,
 				7E46179F2E469E6900EFAA01 /* ChatService.swift in Sources */,

--- a/HeyFriend/App/HeyFriendApp.swift
+++ b/HeyFriend/App/HeyFriendApp.swift
@@ -59,6 +59,8 @@ struct HeyFriendApp: App {
     // Applying color theme
     @AppStorage(SettingsKeys.appAppearance) private var appearanceRaw = AppAppearance.system.rawValue
 
+    // ⬇️ Added this to refresh when app becomes active
+    @Environment(\.scenePhase) private var scenePhase
     
     var body: some Scene {
         let appearance = AppAppearance(rawValue: appearanceRaw) ?? AppAppearance.system
@@ -71,6 +73,15 @@ struct HeyFriendApp: App {
                     WelcomeView().preferredColorScheme(appearance.colorScheme)
                 }
             }.environmentObject(auth)
+            // ⬇️ ADDED: initial entitlement sync + start background listener
+           .task { EntitlementSync.shared.start() }
+
+           // ⬇️ ADDED: refresh when app returns to foreground
+           .onChange(of: scenePhase) { phase in
+               if phase == .active {
+                   Task { await EntitlementSync.shared.refresh() }
+               }
+           }
         }
     } 
 }

--- a/HeyFriend/Shared/Services/Billing/EntitlementSync.swift
+++ b/HeyFriend/Shared/Services/Billing/EntitlementSync.swift
@@ -1,0 +1,110 @@
+//
+//  EntitlementSync.swift
+//  HeyFriend
+//
+//  Created by Denis Tatar 2 on 9/9/25.
+//
+
+import Foundation
+import StoreKit
+import FirebaseAuth
+
+@MainActor
+final class EntitlementSync {
+    static let shared = EntitlementSync()
+    private init() {}
+
+    // Keep these in one place (add/remove yearly if not used)
+    private let plusIDs: Set<String> = [
+        "com.heyfriend.plus.monthly",
+        "com.heyfriend.plus.yearly"
+    ]
+
+    // Convenience over @AppStorage so we can write from anywhere.
+    private var hasPlusFlag: Bool {
+        get { UserDefaults.standard.bool(forKey: "hf.hasPlus") }
+        set { UserDefaults.standard.set(newValue, forKey: "hf.hasPlus") }
+    }
+
+    private var updatesTask: Task<Void, Never>?
+
+    /// Call this once at app launch.
+    func start() {
+        // 1) Do an initial refresh
+        Task { await refresh() }
+        // 2) Begin listening for changes from the App Store
+        if updatesTask == nil {
+            updatesTask = Task { await listenForTransactionUpdates() }
+        }
+    }
+
+    /// Re-check current entitlements and mirror to local flag + Firestore.
+    func refresh() async {
+        // 1) Find an active Plus transaction (if any)
+        var activePlus: Transaction?
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let tx) = result,
+               tx.productType == .autoRenewable,
+               plusIDs.contains(tx.productID),
+               tx.revocationDate == nil,
+               (tx.expirationDate ?? .distantFuture) > Date() {
+                activePlus = tx
+                break
+            }
+        }
+        
+        // 2) Flip local flag
+        hasPlusFlag = (activePlus != nil)
+        
+        // 3) Write to Firestore once (with metadata if active)
+        guard let uid = (AuthService.shared.userId ?? Auth.auth().currentUser?.uid) else { return }
+        
+        if let tx = activePlus {
+            let original = tx.originalID ?? tx.id
+            try? await FirestoreService.shared.setPlus(
+                uid: uid,
+                productId: tx.productID,
+                originalTransactionId: String(original),
+                expiresAt: tx.expirationDate
+            )
+        } else {
+            try? await FirestoreService.shared.setFree(uid: uid)
+        }
+    }
+
+    // MARK: - Live updates
+    private func listenForTransactionUpdates() async {
+        for await result in Transaction.updates {
+            if case .verified(let tx) = result {
+                await apply(tx)
+                await tx.finish()
+            }
+        }
+    }
+
+    private func apply(_ tx: Transaction) async {
+        let valid =
+            tx.productType == .autoRenewable &&
+            plusIDs.contains(tx.productID) &&
+            tx.revocationDate == nil &&
+            (tx.expirationDate ?? .distantFuture) > Date()
+
+        // Flip local flag
+        hasPlusFlag = valid
+
+        // Mirror to Firestore (with metadata if valid)
+        guard let uid = (AuthService.shared.userId ?? Auth.auth().currentUser?.uid) else { return }
+
+        if valid {
+            let original = tx.originalID ?? tx.id
+            try? await FirestoreService.shared.setPlus(
+                uid: uid,
+                productId: tx.productID,
+                originalTransactionId: String(original),
+                expiresAt: tx.expirationDate
+            )
+        } else {
+            try? await FirestoreService.shared.setFree(uid: uid)
+        }
+    }
+}

--- a/HeyFriend/StoreKit.storekit
+++ b/HeyFriend/StoreKit.storekit
@@ -1,0 +1,145 @@
+{
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
+  "identifier" : "AB6D5C98",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+
+  ],
+  "settings" : {
+    "_applicationInternalID" : "6752298724",
+    "_developerTeamID" : "L7C4H63L7Z",
+    "_failTransactionsEnabled" : false,
+    "_lastSynchronizedDate" : 779125095.85241604,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ]
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "21776835",
+      "localizations" : [
+
+      ],
+      "name" : "HeyFriend Plus",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "9.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "6752301007",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Monthly subscription to access HeyFriend Plus",
+              "displayName" : "HeyFriend Plus Monthly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.heyfriend.plus.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "HeyFriend Plus Monthly",
+          "subscriptionGroupID" : "21776835",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "59.99",
+          "familyShareable" : false,
+          "groupNumber" : 2,
+          "internalID" : "6752301097",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "com.heyfriend.plus.yearly",
+              "displayName" : "HeyFriend Plus Yearly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.heyfriend.plus.yearly",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "HeyFriend Plus Yearly",
+          "subscriptionGroupID" : "21776835",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}


### PR DESCRIPTION
- Implement Plus paywall with live prices and purchase/restore (StoreKit 2)
- Add EntitlementSync (launch/foreground refresh + Transaction.updates observer)
- Persist entitlements to Firestore with metadata:
  plan, store, productId, originalTransactionId, expiresAt, updatedAt
- Expand EntitlementsDTO with optional fields (backward-compatible)
- Add setPlus/setFree in FirestoreService (merge-safe; clears stale fields)
- Gate features via @AppStorage("hf.hasPlus"); add Manage Subscription link
- Add StoreKit.storekit for local testing and scheme hookup
- Minor cleanup: remove duplicate writes, fix param labels, logs